### PR TITLE
Upgrading org.slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgraded org.slf4j to latest "safest" version as 1.8.x is still in alpha on maven repository so we don't need to rush it, IMHO