### PR TITLE
#523 Create regression test for /admin/project/list [2-4h]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
+.classpath
+.project
+.settings
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ buildNumber.properties
 .classpath
 .project
 .settings
-.gitignore
+.tern-project

--- a/pom.xml
+++ b/pom.xml
@@ -525,13 +525,11 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+		<dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>2.53.0</version>
-            <scope>test</scope>
+            <artifactId>selenium-server</artifactId>
+            <version>3.0.1</version>
         </dependency>
-        
         <!-- Needed by Selenium to avoid "java.lang.NoClassDefFoundError: org/apache/http/conn/HttpClientConnectionManager" -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/ai/elimu/util/MailChimpApiHelper.java
+++ b/src/main/java/ai/elimu/util/MailChimpApiHelper.java
@@ -43,7 +43,7 @@ public class MailChimpApiHelper {
         logger.info("getMemberInfo");
         
         String memberInfo = null;
-        
+         
         try {
             String emailMd5Hash = DigestUtils.md5Hex(email);
             URL url = new URL (BASE_URL + "/lists/" + LIST_ID + "/members/" + emailMd5Hash);

--- a/src/test/java/selenium/DomainHelper.java
+++ b/src/test/java/selenium/DomainHelper.java
@@ -3,8 +3,8 @@ package selenium;
 public class DomainHelper {
     
     public static String getBaseUrl() {
-      return "http://localhost:8080/webapp";
-     // return "http://test.elimu.ai";
+     //return "http://localhost:8080/webapp";
+     return "http://test.elimu.ai";
     }
     
     public static String getRestUrlV1() {

--- a/src/test/java/selenium/DomainHelper.java
+++ b/src/test/java/selenium/DomainHelper.java
@@ -3,7 +3,7 @@ package selenium;
 public class DomainHelper {
     
     public static String getBaseUrl() {
-//        return "http://localhost:8080/webapp";
+      //return "http://localhost:8080/webapp";
         return "http://test.elimu.ai";
     }
     

--- a/src/test/java/selenium/DomainHelper.java
+++ b/src/test/java/selenium/DomainHelper.java
@@ -3,8 +3,8 @@ package selenium;
 public class DomainHelper {
     
     public static String getBaseUrl() {
-      //return "http://localhost:8080/webapp";
-        return "http://test.elimu.ai";
+      return "http://localhost:8080/webapp";
+     // return "http://test.elimu.ai";
     }
     
     public static String getRestUrlV1() {

--- a/src/test/java/selenium/web/WelcomePage.java
+++ b/src/test/java/selenium/web/WelcomePage.java
@@ -1,6 +1,7 @@
 package selenium.web;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;

--- a/src/test/java/selenium/web/WelcomePage.java
+++ b/src/test/java/selenium/web/WelcomePage.java
@@ -1,8 +1,5 @@
 package selenium.web;
 
-import java.util.List;
-import java.util.function.Function;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/selenium/web/WelcomePageTest.java
+++ b/src/test/java/selenium/web/WelcomePageTest.java
@@ -5,7 +5,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.MethodRule;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.PageFactory;
 import selenium.DomainHelper;
 
@@ -19,8 +22,8 @@ public class WelcomePageTest {
     private WebDriver driver;
 
     @Before
-    public void setUp() {
-        driver = new FirefoxDriver();
+    public void setUp() { 	
+    	driver = new FirefoxDriver();    		
         driver.get(DomainHelper.getBaseUrl());
     }
 

--- a/src/test/java/selenium/web/WelcomePageTest.java
+++ b/src/test/java/selenium/web/WelcomePageTest.java
@@ -5,10 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.MethodRule;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.htmlunit.HtmlUnitDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.PageFactory;
 import selenium.DomainHelper;
 

--- a/src/test/java/selenium/web/admin/project/ProjectListPage.java
+++ b/src/test/java/selenium/web/admin/project/ProjectListPage.java
@@ -1,0 +1,31 @@
+package selenium.web.admin.project;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import selenium.ErrorHelper;
+
+public class ProjectListPage {
+
+	  private WebDriver driver;
+	    
+	    @FindBy(className = "project")
+	    private WebElement projectListItem;
+
+	    public ProjectListPage(WebDriver driver) {
+	        this.driver = driver;
+	        
+	        WebDriverWait webDriverWait = new WebDriverWait(driver, 10);
+	        webDriverWait.until(ExpectedConditions.presenceOfElementLocated(By.id("adminProjectListPage")));
+	        
+	        ErrorHelper.verifyNoScriptOrMarkupError(driver);
+	    }
+	    
+	    public Boolean checkIfListItemIsEmpty() {
+	    	return projectListItem.isDisplayed();
+	    }
+}

--- a/src/test/java/selenium/web/admin/project/ProjectListTest.java
+++ b/src/test/java/selenium/web/admin/project/ProjectListTest.java
@@ -1,0 +1,40 @@
+package selenium.web.admin.project;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.support.PageFactory;
+
+import ai.elimu.model.enums.Role;
+import selenium.DomainHelper;
+import selenium.ScreenshotOnFailureRule;
+import selenium.SignOnHelper;
+
+public class ProjectListTest {
+
+    @Rule
+    public MethodRule methodRule = new ScreenshotOnFailureRule();
+    
+    private WebDriver driver;
+
+    @Before
+    public void setUp() {
+        driver = new FirefoxDriver();
+        SignOnHelper.signOnRole(driver, Role.ADMIN);
+        driver.get(DomainHelper.getBaseUrl() + "/admin/project/list");
+    }
+    
+    @Test
+    public void testListNotEmpty() {
+
+    	ProjectListPage projectListPage = PageFactory.initElements(driver, ProjectListPage.class);
+    	Boolean isEmpty = projectListPage.checkIfListItemIsEmpty();
+    	
+    	assertTrue(isEmpty);
+    }
+}


### PR DESCRIPTION
In order to be able to run selenium tests on newer versions of firefox without problems, I have upgraded the selenium dependency to 3.0.1.
In order to use it, we need gecko driver (new web driver for Firefox). 
I used **gecko driver 0.14**, anything higher causes bugs. 

**Should the build fail** because of tests, we need to add this gecko driver to our server. 
In order to do that: 
Download driver from github: 
`wget https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-linux64.tar.gz` 

Extract: `tar -xvzf geckodriver*` 

Make it executable: `chmod +x geckodriver`

 Add it to our bin: `sudo mv geckodriver /usr/local/bin/`