### PR TITLE
#603: literacyapp.xml for Jetty 9 appstore_secret attribute is missing

### DIFF
--- a/src/main/config/server-test/usr/local/jetty-distribution-9.3.8.v20160314/webapps/literacyapp.xml
+++ b/src/main/config/server-test/usr/local/jetty-distribution-9.3.8.v20160314/webapps/literacyapp.xml
@@ -28,6 +28,10 @@ This file is placed on the test server under jetty.home/contexts/
     <Arg>github_api_secret</Arg>
     <Arg>************</Arg>
   </Call>
+  <Call name="setAttribute">
+    <Arg>appstore_secret</Arg>
+    <Arg>************</Arg>
+  </Call>
   <Set name="virtualHosts">
     <Array type="java.lang.String">
       <Item>test.elimu.ai</Item>


### PR DESCRIPTION
603 - In the literacyapp.xml for Jetty 9 appstore_secret attribute is missing (getting NullPointerException)