### PR TITLE
639 Fix DataIntegrityViolationException

### DIFF
--- a/src/main/resources/db/migration/2000054.sql
+++ b/src/main/resources/db/migration/2000054.sql
@@ -1,0 +1,3 @@
+# 2.0.54
+
+ALTER TABLE AppCollection_AppCategory DROP INDEX UK_dyb2nkjp3u386hbjphd71bcud;


### PR DESCRIPTION
- Do not require AppCategory ids to be unique across multiple
AppCollections