### PR TITLE
#714 Extract content from ePUB storybook

### DIFF
--- a/src/main/resources/db/migration/2000085.sql
+++ b/src/main/resources/db/migration/2000085.sql
@@ -1,0 +1,3 @@
+# 2.0.85
+
+ALTER TABLE StoryBook MODIFY paragraphs VARCHAR(1000);


### PR DESCRIPTION
- Fix for "com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'paragraphs' at row 1"
- Increase length of "paragraphs" column from 255 to 1000.