### PR TITLE
[#1401] Skip Edit Contribution Page for localhost development

### DIFF
--- a/src/main/java/ai/elimu/web/content/MainContentController.java
+++ b/src/main/java/ai/elimu/web/content/MainContentController.java
@@ -105,7 +105,7 @@ public class MainContentController {
             return "redirect:/content/contributor/add-email";
         } else if (StringUtils.isBlank(contributor.getFirstName()) || StringUtils.isBlank(contributor.getLastName())) {
             return "redirect:/content/contributor/edit-name";
-        } else if (StringUtils.isBlank(contributor.getMotivation()) && EnvironmentContextLoaderListener.env!=Environment.DEV) {
+        } else if (StringUtils.isBlank(contributor.getMotivation()) && (EnvironmentContextLoaderListener.env != Environment.DEV)) {
             return "redirect:/content/contributor/edit-motivation";
         } else {
             // Redirect to originally requested URL

--- a/src/main/java/ai/elimu/web/content/MainContentController.java
+++ b/src/main/java/ai/elimu/web/content/MainContentController.java
@@ -24,6 +24,9 @@ import ai.elimu.dao.VideoDao;
 import ai.elimu.dao.WordContributionEventDao;
 import ai.elimu.dao.WordDao;
 import ai.elimu.model.contributor.Contributor;
+import ai.elimu.model.v2.enums.Environment;
+import ai.elimu.web.context.EnvironmentContextLoaderListener;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +106,7 @@ public class MainContentController {
             return "redirect:/content/contributor/add-email";
         } else if (StringUtils.isBlank(contributor.getFirstName()) || StringUtils.isBlank(contributor.getLastName())) {
             return "redirect:/content/contributor/edit-name";
-        } else if (StringUtils.isBlank(contributor.getMotivation())) {
+        } else if (StringUtils.isBlank(contributor.getMotivation()) && EnvironmentContextLoaderListener.env!=Environment.DEV) {
             return "redirect:/content/contributor/edit-motivation";
         } else {
             // Redirect to originally requested URL

--- a/src/main/java/ai/elimu/web/content/MainContentController.java
+++ b/src/main/java/ai/elimu/web/content/MainContentController.java
@@ -26,7 +26,6 @@ import ai.elimu.dao.WordDao;
 import ai.elimu.model.contributor.Contributor;
 import ai.elimu.model.v2.enums.Environment;
 import ai.elimu.web.context.EnvironmentContextLoaderListener;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
This PR adds a condition in `MainContentController` to redirect to `/content/contributor/edit-motivation` only if the environment isn't `dev`.
This way localhost environments do not redirect to the Edit Motivation page on logging in.

Do let me know if you would rather prefer for the condition to be extracted into a separate function `isContributorADeveloper()` in a new Utils class/`EnvironmentContextLoaderListener` for better readability.