### PR TITLE
Error while signing on using Discord if no avatar #1649

### DIFF
--- a/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
+++ b/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
@@ -132,24 +132,24 @@ public class SignOnControllerDiscord {
                 String id = String.valueOf(idAsLong);
                 contributor.setProviderIdDiscord(id);
             }
+            private static final String DEFAULT_AVATAR_URL = "https://e7.pngegg.com/pngimages/84/165/"
+        + "png-clipart-united-states-avatar-organization-information"
+        + "-user-avatar-service-computer-wallpaper-thumbnail.png";
+
+
             if (jsonObject.has("avatar")) {
-                 if (jsonObject.get("avatar") instanceof String) {
+                if (jsonObject.get("avatar") instanceof String) {
                     String avatar = jsonObject.getString("avatar");
                     if (!avatar.isEmpty()) {
                         String uriAvatar = "https://cdn.discordapp.com/avatars/" + jsonObject.getLong("id") + "/" + avatar + ".png";
                         logger.info(uriAvatar);
                         contributor.setImageUrl(uriAvatar);
                     } else {
-                        // Handle case where avatar field is empty or not provided
-                        contributor.setImageUrl("https://e7.pngegg.com/pngimages/84/165/"
-                        +"png-clipart-united-states-avatar-organization-information"
-                                +"-user-avatar-service-computer-wallpaper-thumbnail.png");
+                        contributor.setImageUrl(DEFAULT_AVATAR_URL);
                     } 
                 } else {
                     logger.warn("Avatar field is not a string: " + jsonObject.get("avatar"));
-                    contributor.setImageUrl("https://e7.pngegg.com/pngimages/84/165/"
-                        +"png-clipart-united-states-avatar-organization-information"
-                                +"-user-avatar-service-computer-wallpaper-thumbnail.png"); // Replace with your default avatar URL
+                    contributor.setImageUrl(DEFAULT_AVATAR_URL);
                 }
             }
             if (jsonObject.has("username")) {

--- a/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
+++ b/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
@@ -132,25 +132,10 @@ public class SignOnControllerDiscord {
                 String id = String.valueOf(idAsLong);
                 contributor.setProviderIdDiscord(id);
             }
-            private static final String DEFAULT_AVATAR_URL = "https://e7.pngegg.com/pngimages/84/165/"
-        + "png-clipart-united-states-avatar-organization-information"
-        + "-user-avatar-service-computer-wallpaper-thumbnail.png";
-
-
-            if (jsonObject.has("avatar")) {
-                if (jsonObject.get("avatar") instanceof String) {
-                    String avatar = jsonObject.getString("avatar");
-                    if (!avatar.isEmpty()) {
-                        String uriAvatar = "https://cdn.discordapp.com/avatars/" + jsonObject.getLong("id") + "/" + avatar + ".png";
-                        logger.info(uriAvatar);
-                        contributor.setImageUrl(uriAvatar);
-                    } else {
-                        contributor.setImageUrl(DEFAULT_AVATAR_URL);
-                    } 
-                } else {
-                    logger.warn("Avatar field is not a string: " + jsonObject.get("avatar"));
-                    contributor.setImageUrl(DEFAULT_AVATAR_URL);
-                }
+            if (!jsonObject.isNull("avatar")) {
+                String uriAvatar = "https://cdn.discordapp.com/avatars/" + jsonObject.getLong("id") + "/" + jsonObject.getString("avatar") + ".png";
+                logger.info("Avatar URL: " + uriAvatar);
+                contributor.setImageUrl(uriAvatar);
             }
             if (jsonObject.has("username")) {
                 contributor.setFirstName(jsonObject.getString("username"));

--- a/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
+++ b/src/main/java/ai/elimu/web/SignOnControllerDiscord.java
@@ -133,9 +133,24 @@ public class SignOnControllerDiscord {
                 contributor.setProviderIdDiscord(id);
             }
             if (jsonObject.has("avatar")) {
-                String uriAvatar = "https://cdn.discordapp.com/avatars/" + jsonObject.getLong("id") + "/" + jsonObject.getString("avatar") + ".png";
-                logger.info(uriAvatar);
-                contributor.setImageUrl(uriAvatar);
+                 if (jsonObject.get("avatar") instanceof String) {
+                    String avatar = jsonObject.getString("avatar");
+                    if (!avatar.isEmpty()) {
+                        String uriAvatar = "https://cdn.discordapp.com/avatars/" + jsonObject.getLong("id") + "/" + avatar + ".png";
+                        logger.info(uriAvatar);
+                        contributor.setImageUrl(uriAvatar);
+                    } else {
+                        // Handle case where avatar field is empty or not provided
+                        contributor.setImageUrl("https://e7.pngegg.com/pngimages/84/165/"
+                        +"png-clipart-united-states-avatar-organization-information"
+                                +"-user-avatar-service-computer-wallpaper-thumbnail.png");
+                    } 
+                } else {
+                    logger.warn("Avatar field is not a string: " + jsonObject.get("avatar"));
+                    contributor.setImageUrl("https://e7.pngegg.com/pngimages/84/165/"
+                        +"png-clipart-united-states-avatar-organization-information"
+                                +"-user-avatar-service-computer-wallpaper-thumbnail.png"); // Replace with your default avatar URL
+                }
             }
             if (jsonObject.has("username")) {
                 contributor.setFirstName(jsonObject.getString("username"));


### PR DESCRIPTION
**Description**

Changes Made:
Enhanced handling of the avatar field in SignOnControllerDiscord.java to ensure robust behavior when the avatar is missing or not a string.

**Details:**

I added validation to check for the avatar field in the JSON response, implemented logic to handle empty or non-string avatar fields, and introduced a default avatar URL fallback mechanism.

**Impact:**

This update ensures the application handles sign-on scenarios without Discord avatars gracefully and consistently, providing a stable user experience.

**Testing:**

Tested locally to verify functionality across different scenarios (avatar present, empty avatar).

**Note:**

The default avatar URL (https://e7.pngegg.com/pngimages/84/165/png-clipart-united-states-avatar-organization-information-user-avatar-service-computer-wallpaper-thumbnail.png) used in this implementation can be replaced with an actual URL pointing to a suitable default image for the application.