### PR TITLE
refactor(dao): LetterSoundCorrespondenceContributionEvent#letterSounds

### DIFF
--- a/src/main/java/ai/elimu/dao/jpa/LetterSoundContributionEventDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/LetterSoundContributionEventDaoJpa.java
@@ -23,9 +23,9 @@ public class LetterSoundContributionEventDaoJpa extends GenericDaoJpa<LetterSoun
         return em.createQuery(
             "SELECT e " + 
             "FROM LetterSoundCorrespondenceContributionEvent e " +
-            "WHERE e.letterSoundCorrespondence = :letterSoundCorrespondence " + 
+            "WHERE e.letterSound = :letterSound " + 
             "ORDER BY e.time DESC")
-            .setParameter("letterSoundCorrespondence", letterSound)
+            .setParameter("letterSound", letterSound)
             .getResultList();
     }
 
@@ -45,7 +45,7 @@ public class LetterSoundContributionEventDaoJpa extends GenericDaoJpa<LetterSoun
         return em.createQuery(
             "SELECT e " + 
             "FROM LetterSoundCorrespondenceContributionEvent e " +
-            "WHERE e.time IN (SELECT MAX(time) FROM LetterSoundCorrespondenceContributionEvent GROUP BY letterSoundCorrespondence_id) " + // TODO: replace with "NOT EXISTS"? - https://stackoverflow.com/a/25694562
+            "WHERE e.time IN (SELECT MAX(time) FROM LetterSoundCorrespondenceContributionEvent GROUP BY letterSound_id) " + // TODO: replace with "NOT EXISTS"? - https://stackoverflow.com/a/25694562
             "ORDER BY e.time ASC")
             .getResultList();
     }

--- a/src/main/java/ai/elimu/dao/jpa/LetterSoundPeerReviewEventDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/LetterSoundPeerReviewEventDaoJpa.java
@@ -28,9 +28,9 @@ public class LetterSoundPeerReviewEventDaoJpa extends GenericDaoJpa<LetterSoundC
         return em.createQuery(
             "SELECT event " + 
             "FROM LetterSoundCorrespondencePeerReviewEvent event " +
-            "WHERE event.letterSoundCorrespondenceContributionEvent.letterSoundCorrespondence = :letterSoundCorrespondence " + 
+            "WHERE event.letterSoundCorrespondenceContributionEvent.letterSound = :letterSound " + 
             "ORDER BY event.time DESC")
-            .setParameter("letterSoundCorrespondence", letterSound)
+            .setParameter("letterSound", letterSound)
             .getResultList();
     }
     

--- a/src/main/java/ai/elimu/model/contributor/LetterSoundCorrespondenceContributionEvent.java
+++ b/src/main/java/ai/elimu/model/contributor/LetterSoundCorrespondenceContributionEvent.java
@@ -10,13 +10,13 @@ public class LetterSoundCorrespondenceContributionEvent extends ContributionEven
 
     @NotNull
     @ManyToOne
-    private LetterSoundCorrespondence letterSoundCorrespondence;
+    private LetterSoundCorrespondence letterSound;
 
-    public LetterSoundCorrespondence getLetterSoundCorrespondence() {
-        return letterSoundCorrespondence;
+    public LetterSoundCorrespondence getLetterSound() {
+        return letterSound;
     }
 
-    public void setLetterSoundCorrespondence(LetterSoundCorrespondence letterSoundCorrespondence) {
-        this.letterSoundCorrespondence = letterSoundCorrespondence;
+    public void setLetterSound(LetterSoundCorrespondence letterSound) {
+        this.letterSound = letterSound;
     }
 }

--- a/src/main/java/ai/elimu/util/db/DbContentImportHelper.java
+++ b/src/main/java/ai/elimu/util/db/DbContentImportHelper.java
@@ -173,7 +173,7 @@ public class DbContentImportHelper {
 
             LetterSoundCorrespondenceContributionEvent letterSoundContributionEvent = new LetterSoundCorrespondenceContributionEvent();
             letterSoundContributionEvent.setContributor(contributor);
-            letterSoundContributionEvent.setLetterSoundCorrespondence(letterSound);
+            letterSoundContributionEvent.setLetterSound(letterSound);
             letterSoundContributionEvent.setRevisionNumber(1);
             letterSoundContributionEvent.setTime(Calendar.getInstance());
             letterSoundContributionEvent.setTimeSpentMs((long)(Math.random() * 10) * 60000L);

--- a/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundCreateController.java
+++ b/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundCreateController.java
@@ -99,7 +99,7 @@ public class LetterSoundCreateController {
             LetterSoundCorrespondenceContributionEvent letterSoundContributionEvent = new LetterSoundCorrespondenceContributionEvent();
             letterSoundContributionEvent.setContributor((Contributor) session.getAttribute("contributor"));
             letterSoundContributionEvent.setTime(Calendar.getInstance());
-            letterSoundContributionEvent.setLetterSoundCorrespondence(letterSound);
+            letterSoundContributionEvent.setLetterSound(letterSound);
             letterSoundContributionEvent.setRevisionNumber(letterSound.getRevisionNumber());
             letterSoundContributionEvent.setComment(StringUtils.abbreviate(request.getParameter("contributionComment"), 1000));
             letterSoundContributionEvent.setTimeSpentMs(System.currentTimeMillis() - Long.valueOf(request.getParameter("timeStart")));

--- a/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundEditController.java
+++ b/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundEditController.java
@@ -119,7 +119,7 @@ public class LetterSoundEditController {
             LetterSoundCorrespondenceContributionEvent letterSoundContributionEvent = new LetterSoundCorrespondenceContributionEvent();
             letterSoundContributionEvent.setContributor((Contributor) session.getAttribute("contributor"));
             letterSoundContributionEvent.setTime(Calendar.getInstance());
-            letterSoundContributionEvent.setLetterSoundCorrespondence(letterSound);
+            letterSoundContributionEvent.setLetterSound(letterSound);
             letterSoundContributionEvent.setRevisionNumber(letterSound.getRevisionNumber());
             letterSoundContributionEvent.setComment(StringUtils.abbreviate(request.getParameter("contributionComment"), 1000));
             letterSoundContributionEvent.setTimeSpentMs(System.currentTimeMillis() - Long.valueOf(request.getParameter("timeStart")));

--- a/src/main/java/ai/elimu/web/content/peer_review/LetterSoundPeerReviewEventCreateController.java
+++ b/src/main/java/ai/elimu/web/content/peer_review/LetterSoundPeerReviewEventCreateController.java
@@ -63,10 +63,10 @@ public class LetterSoundPeerReviewEventCreateController {
         letterSoundPeerReviewEventDao.create(letterSoundPeerReviewEvent);
         
         if (!EnvironmentContextLoaderListener.PROPERTIES.isEmpty()) {
-            String contentUrl = "https://" + EnvironmentContextLoaderListener.PROPERTIES.getProperty("content.language").toLowerCase() + ".elimu.ai/content/letterSoundCorrespondence/edit/" + letterSoundContributionEvent.getLetterSoundCorrespondence().getId();
+            String contentUrl = "https://" + EnvironmentContextLoaderListener.PROPERTIES.getProperty("content.language").toLowerCase() + ".elimu.ai/content/letterSoundCorrespondence/edit/" + letterSoundContributionEvent.getLetterSound().getId();
             DiscordHelper.sendChannelMessage(
                     "Letter-sound correspondence peer-reviewed: " + contentUrl, 
-                    "\"" + letterSoundContributionEvent.getLetterSoundCorrespondence().getLetters().stream().map(Letter::getText).collect(Collectors.joining()) + "\"",
+                    "\"" + letterSoundContributionEvent.getLetterSound().getLetters().stream().map(Letter::getText).collect(Collectors.joining()) + "\"",
                     "Comment: \"" + letterSoundPeerReviewEvent.getComment() + "\"",
                     letterSoundPeerReviewEvent.isApproved(),
                     null
@@ -85,7 +85,7 @@ public class LetterSoundPeerReviewEventCreateController {
         }
         logger.info("approvedCount: " + approvedCount);
         logger.info("notApprovedCount: " + notApprovedCount);
-        LetterSoundCorrespondence letterSound = letterSoundContributionEvent.getLetterSoundCorrespondence();
+        LetterSoundCorrespondence letterSound = letterSoundContributionEvent.getLetterSound();
         if (approvedCount >= notApprovedCount) {
             letterSound.setPeerReviewStatus(PeerReviewStatus.APPROVED);
         } else {
@@ -93,6 +93,6 @@ public class LetterSoundPeerReviewEventCreateController {
         }
         letterSoundDao.update(letterSound);
 
-        return "redirect:/content/letter-sound/edit/" + letterSoundContributionEvent.getLetterSoundCorrespondence().getId() + "#contribution-events";
+        return "redirect:/content/letter-sound/edit/" + letterSoundContributionEvent.getLetterSound().getId() + "#contribution-events";
     }
 }

--- a/src/main/resources/META-INF/jpa-schema-export.sql
+++ b/src/main/resources/META-INF/jpa-schema-export.sql
@@ -406,7 +406,7 @@
         time datetime,
         timeSpentMs bigint,
         contributor_id bigint,
-        letterSoundCorrespondence_id bigint,
+        letterSound_id bigint,
         primary key (id)
     ) engine=MyISAM;
 
@@ -903,8 +903,8 @@
        references Contributor (id);
 
     alter table LetterSoundCorrespondenceContributionEvent 
-       add constraint FKm1rttrlv6gxibd85a5sc3c4js 
-       foreign key (letterSoundCorrespondence_id) 
+       add constraint FKmgdglk92d302rk5e2fokfc77b 
+       foreign key (letterSound_id) 
        references LetterSoundCorrespondence (id);
 
     alter table LetterSoundCorrespondencePeerReviewEvent 

--- a/src/main/resources/db/migration/2004008.sql
+++ b/src/main/resources/db/migration/2004008.sql
@@ -1,0 +1,5 @@
+# 2.4.8
+
+# "letterSoundCorrespondence" → "letterSound"
+ALTER TABLE `LetterSoundCorrespondenceContributionEvent` DROP COLUMN `letterSound_id`;
+ALTER TABLE `LetterSoundCorrespondenceContributionEvent` CHANGE `letterSoundCorrespondence_id` `letterSound_id` bigint(20) NOT NULL;

--- a/src/main/webapp/WEB-INF/jsp/content/letter-sound/peer-reviews/pending.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/letter-sound/peer-reviews/pending.jsp
@@ -25,7 +25,7 @@
                 </thead>
                 <tbody>
                     <c:forEach var="letterSoundContributionEvent" items="${letterSoundContributionEventsPendingPeerReview}">
-                        <c:set var="letterSound" value="${letterSoundContributionEvent.letterSoundCorrespondence}" />
+                        <c:set var="letterSound" value="${letterSoundContributionEvent.letterSound}" />
                         <tr>
                             <td style="font-size: 2em;">
                                 " <c:forEach var="letter" items="${letterSound.letters}"><a href="<spring:url value='/content/letter/edit/${letter.id}' />">${letter.text} </a> </c:forEach> "
@@ -68,7 +68,7 @@
                                 <fmt:formatDate value="${letterSoundContributionEvent.time.time}" pattern="yyyy-MM-dd HH:mm" />
                             </td>
                             <td>
-                                <a href="<spring:url value='/content/letter-sound/edit/${letterSoundContributionEvent.letterSoundCorrespondence.id}#peer-review' />" target="_blank"><fmt:message key="peer.review" /></a>
+                                <a href="<spring:url value='/content/letter-sound/edit/${letterSoundContributionEvent.letterSound.id}#peer-review' />" target="_blank"><fmt:message key="peer.review" /></a>
                             </td>
                         </tr>
                     </c:forEach>


### PR DESCRIPTION
refs #1677

> [!WARNING]
> Includes DB migration script for renaming a column in production from `letterSoundCorrespondence_id` to `letterSound_id`.

Current structure in the production database:
```sql
MariaDB [webapp-HIN]> SHOW CREATE TABLE LetterSoundCorrespondenceContributionEvent;
```
```sql
| LetterSoundCorrespondenceContributionEvent | CREATE TABLE `LetterSoundCorrespondenceContributionEvent` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `comment` varchar(1000) DEFAULT NULL,
  `revisionNumber` int(11) NOT NULL,
  `time` datetime NOT NULL,
  `timeSpentMs` bigint(20) NOT NULL,
  `contributor_id` bigint(20) NOT NULL,
  `letterSoundCorrespondence_id` bigint(20) NOT NULL,
  PRIMARY KEY (`id`),
  KEY `FKouellxtx1de1wpddv5x72h9jn` (`contributor_id`),
  KEY `FKm1rttrlv6gxibd85a5sc3c4js` (`letterSoundCorrespondence_id`)
) ENGINE=MyISAM AUTO_INCREMENT=91 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
```