### PR TITLE
chore(jetty): add webappcontext for tagalog language

### DIFF
--- a/src/main/config/centos-stream-9/opt/jetty-base/webapps/webapp-TGL.xml
+++ b/src/main/config/centos-stream-9/opt/jetty-base/webapps/webapp-TGL.xml
@@ -6,7 +6,7 @@
   <Set name="war"><SystemProperty name="jetty.base"/>/webapps/webapp.war</Set>
   <Set name="virtualHosts">
     <Array type="java.lang.String">
-      <Item>hin.elimu.ai</Item>
+      <Item>tgl.elimu.ai</Item>
     </Array>
   </Set>
   <Call name="setAttribute">
@@ -15,11 +15,11 @@
   </Call>
   <Call name="setAttribute">
     <Arg>content_language</Arg>
-    <Arg>HIN</Arg>
+    <Arg>TGL</Arg>
   </Call>
   <Call name="setAttribute">
     <Arg>jdbc_url</Arg>
-    <Arg>jdbc:mysql://localhost/webapp-HIN?useUnicode=true&amp;characterEncoding=utf8</Arg>
+    <Arg>jdbc:mysql://localhost/webapp-TGL?useUnicode=true&amp;characterEncoding=utf8</Arg>
   </Call>
   <Call name="setAttribute">
     <Arg>jdbc_username</Arg>

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -11,7 +11,7 @@ jobs.enabled = true
 pom.version=${project.version}
 
 # The language of the educational content
-# See https://github.com/elimu-ai/model/blob/main/src/main/java/ai/elimu/model/enums/Language.java
+# See https://github.com/elimu-ai/model/blob/main/src/main/java/ai/elimu/model/v2/enums/Language.java
 content.language=ENG
 
 # Create free API key using https://www.covalenthq.com/platform/#/auth/register/


### PR DESCRIPTION
Set virtual hosts for `tgl.elimu.ai`, `hin.elimu.ai`.

refs #1730