### PR TITLE
test(rest): add regression testing to github action

### DIFF
--- a/.github/workflows/maven-regression-test.yml
+++ b/.github/workflows/maven-regression-test.yml
@@ -1,0 +1,33 @@
+name: Maven Regression Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  regression_test_hindi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: maven
+      - run: mvn clean
+      - run: mvn verify -P regression-testing-rest -D base.url=http://hin.elimu.ai
+  
+  regression_test_tagalog:
+    needs: regression_test_hindi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: maven
+      - run: mvn clean
+      - run: mvn verify -P regression-testing-rest -D base.url=http://tgl.elimu.ai


### PR DESCRIPTION
Verifies that the REST API is returning data.

Not optimal, because it doesn't test the changes introduced in PRs triggering the test. It only tests the current deployment in production. But at least this helps us get faster notifications when the REST API breaks in production.

> [!NOTE]
> The future goal is to launch the webapp on localhost (as part of a GitHub Action workflow), and run these regression tests against http://localhost:8080/webapp/rest/ for every pull request. This change is a step in that direction.

closes #1768