### PR TITLE
Update Hibernate Validator dependency coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,10 +419,12 @@
    <version>2.0.1.Final</version>
   </dependency>
   <dependency>
-   <groupId>org.hibernate</groupId>
+   <groupId>org.hibernate.validator</groupId>
    <artifactId>hibernate-validator</artifactId>
    <version>6.1.7.Final</version>
   </dependency>
+
+
 
   <dependency>
    <groupId>commons-lang</groupId>


### PR DESCRIPTION
 ### Description:
This PR addresses issue #1742  by updating the dependency coordinates for Hibernate Validator in the pom.xml file. The artifact org.hibernate:hibernate-validator:jar:6.1.7.Final has been relocated to org.hibernate.validator:hibernate-validator:6.1.7.Final. This change resolves the warning related to the relocated artifact and ensures the correct version is used.

### Changes :
- Updated the pom.xml file to use the correct dependency coordinates for Hibernate Validator.
### Testing :
- Ran mvn clean compile to ensure the project compiles successfully without warnings.
- Verified that all existing tests pass.
### Notes :
- This PR is based on the update-dependencies branch.
- No additional changes were made beyond updating the dependency coordinates.
### Screenshots
![Issue-solved](https://github.com/user-attachments/assets/4db35559-0bb1-4c5d-855f-7fbb5b041515)





