### PR TITLE
1417 improve the navigation bar UI

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/content/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/layout.jsp
@@ -162,7 +162,7 @@
                                 </c:choose>
                                 <c:choose>
                                     <c:when test="${not empty contributor.firstName}">
-                                        <span class="contributor-name-wrapper">
+                                        <span class="contributor-name-wrapper" aria-label="${contributor.firstName}>
                                             <span><c:out value="${contributor.firstName}" /></span>
                                             <span><c:out value="${contributor.lastName}" /></span>
                                         </span>

--- a/src/main/webapp/WEB-INF/jsp/content/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/layout.jsp
@@ -162,7 +162,10 @@
                                 </c:choose>
                                 <c:choose>
                                     <c:when test="${not empty contributor.firstName}">
-                                        <c:out value="${contributor.firstName}" />&nbsp;<c:out value="${contributor.lastName}" />
+                                        <span class="contributor-name-wrapper">
+                                            <span><c:out value="${contributor.firstName}" /></span>
+                                            <span><c:out value="${contributor.lastName}" /></span>
+                                        </span>
                                     </c:when>
                                     <c:when test="${not empty contributor.providerIdWeb3}">
                                         ${fn:substring(contributor.providerIdWeb3, 0, 6)}...${fn:substring(contributor.providerIdWeb3, 38, 42)}

--- a/src/main/webapp/WEB-INF/jsp/content/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/layout.jsp
@@ -55,6 +55,21 @@
                         </li>
                         
                         <li class="divider"></li>
+
+                        <li>
+                            <a class="btn tokenButtonSideNav" href="<spring:url value='/sign-on/web3' />">
+                                <svg style="width: 24px; height: 24px; top: 6px; position: relative; right: 5px;" viewBox="0 0 784.37 1277.39" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xodm="http://www.corel.com/coreldraw/odm/2003">
+                                    <g>
+                                        <polygon fill="#343434" fill-rule="nonzero" points="392.07,0 383.5,29.11 383.5,873.74 392.07,882.29 784.13,650.54 "/>
+                                        <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,0 -0,650.54 392.07,882.29 392.07,472.33 "/>
+                                        <polygon fill="#3C3C3B" fill-rule="nonzero" points="392.07,956.52 387.24,962.41 387.24,1263.28 392.07,1277.38 784.37,724.89 "/>
+                                        <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,1277.38 392.07,956.52 -0,724.89 "/>
+                                        <polygon fill="#141414" fill-rule="nonzero" points="392.07,882.29 784.13,650.54 392.07,472.33 "/>
+                                        <polygon fill="#393939" fill-rule="nonzero" points="0,650.54 392.07,882.29 392.07,472.33 "/>
+                                    </g>
+                                </svg>&nbsp;Connect wallet
+                            </a>
+                        </li>
                         
                         <li class="grey-text"><b><fmt:message key="community" /></b></li>
                         <li><a href="<spring:url value='/content/contributor/list' />"><i class="material-icons left">group</i><fmt:message key="contributors" /></a></li>

--- a/src/main/webapp/WEB-INF/jsp/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/layout.jsp
@@ -119,7 +119,7 @@
                                         </c:choose>
                                         <c:choose>
                                             <c:when test="${not empty contributor.firstName}">
-                                                <span class="contributor-name-wrapper">
+                                                <span class="contributor-name-wrapper" aria-label="${contributor.firstName}>
                                                     <span><c:out value="${contributor.firstName}" /></span>
                                                     <span><c:out value="${contributor.lastName}" /></span>
                                                 </span>

--- a/src/main/webapp/WEB-INF/jsp/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/layout.jsp
@@ -69,7 +69,21 @@
                                 <li><a href="<spring:url value='/sign-on' />"><fmt:message key="sign.on" /></a></li>
                             </ul>
                             <ul id="nav-mobile" class="side-nav">
-                                <li><a href="<spring:url value='/sign-on' />"><fmt:message key="sign.on" /></a></li>
+                                <li>
+                                    <a class="btn tokenButtonSideNav" href="<spring:url value='/sign-on/web3' />">
+                                        <svg style="width: 24px; height: 24px; top: 6px; position: relative; right: 5px;" viewBox="0 0 784.37 1277.39" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xodm="http://www.corel.com/coreldraw/odm/2003">
+                                            <g>
+                                                <polygon fill="#343434" fill-rule="nonzero" points="392.07,0 383.5,29.11 383.5,873.74 392.07,882.29 784.13,650.54 "/>
+                                                <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,0 -0,650.54 392.07,882.29 392.07,472.33 "/>
+                                                <polygon fill="#3C3C3B" fill-rule="nonzero" points="392.07,956.52 387.24,962.41 387.24,1263.28 392.07,1277.38 784.37,724.89 "/>
+                                                <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,1277.38 392.07,956.52 -0,724.89 "/>
+                                                <polygon fill="#141414" fill-rule="nonzero" points="392.07,882.29 784.13,650.54 392.07,472.33 "/>
+                                                <polygon fill="#393939" fill-rule="nonzero" points="0,650.54 392.07,882.29 392.07,472.33 "/>
+                                            </g>
+                                        </svg>&nbsp;Connect wallet
+                                    </a>
+                                </li>
+                                <li><a class="btn signOnBtn" href="<spring:url value='/sign-on' />"><fmt:message key="sign.on" /></a></li>
                             </ul>
                         </sec:authorize>
                         <sec:authorize access="hasAnyRole('ROLE_ADMIN','ROLE_CONTRIBUTOR')">

--- a/src/main/webapp/WEB-INF/jsp/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/layout.jsp
@@ -87,6 +87,22 @@
                             </ul>
                         </sec:authorize>
                         <sec:authorize access="hasAnyRole('ROLE_ADMIN','ROLE_CONTRIBUTOR')">
+                            <ul id="nav-mobile" class="side-nav">
+                                <li>
+                                    <a class="btn tokenButtonSideNav" href="<spring:url value='/sign-on/web3' />">
+                                        <svg style="width: 24px; height: 24px; top: 6px; position: relative; right: 5px;" viewBox="0 0 784.37 1277.39" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xodm="http://www.corel.com/coreldraw/odm/2003">
+                                            <g>
+                                                <polygon fill="#343434" fill-rule="nonzero" points="392.07,0 383.5,29.11 383.5,873.74 392.07,882.29 784.13,650.54 "/>
+                                                <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,0 -0,650.54 392.07,882.29 392.07,472.33 "/>
+                                                <polygon fill="#3C3C3B" fill-rule="nonzero" points="392.07,956.52 387.24,962.41 387.24,1263.28 392.07,1277.38 784.37,724.89 "/>
+                                                <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,1277.38 392.07,956.52 -0,724.89 "/>
+                                                <polygon fill="#141414" fill-rule="nonzero" points="392.07,882.29 784.13,650.54 392.07,472.33 "/>
+                                                <polygon fill="#393939" fill-rule="nonzero" points="0,650.54 392.07,882.29 392.07,472.33 "/>
+                                            </g>
+                                        </svg>&nbsp;Connect wallet
+                                    </a>
+                                </li>
+                            </ul>
                             <ul class="right">
                                 <a href="<spring:url value='/content' />">
                                     <div class="chip">
@@ -103,7 +119,10 @@
                                         </c:choose>
                                         <c:choose>
                                             <c:when test="${not empty contributor.firstName}">
-                                                <c:out value="${contributor.firstName}" />&nbsp;<c:out value="${contributor.lastName}" />
+                                                <span class="contributor-name-wrapper">
+                                                    <span><c:out value="${contributor.firstName}" /></span>
+                                                    <span><c:out value="${contributor.lastName}" /></span>
+                                                </span>
                                             </c:when>
                                             <c:when test="${not empty contributor.providerIdWeb3}">
                                                 ${fn:substring(contributor.providerIdWeb3, 0, 6)}...${fn:substring(contributor.providerIdWeb3, 38, 42)}

--- a/src/main/webapp/static/css/styles.css
+++ b/src/main/webapp/static/css/styles.css
@@ -214,9 +214,22 @@ form {
     top: 50%;
 }
 
+.contributor-name-wrapper {
+    display: inline-block;
+    white-space: nowrap;
+    width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+}
+
 @media screen and (max-width:1000px) {
     .btn.tokenButton {
         display: none;
+    }
+
+    .contributor-name-wrapper {
+        width: 30px;
     }
 }
 

--- a/src/main/webapp/static/css/styles.css
+++ b/src/main/webapp/static/css/styles.css
@@ -134,6 +134,11 @@ footer.page-footer .footer-copyright {
     background: linear-gradient(135deg, rgba(255,255,255, .4) 0%, rgba(255,255,255, .2) 100%);
 }
 
+.btn.tokenButtonSideNav, .btn.signOnBtn {
+    border-radius: 32px;
+    background: linear-gradient(135deg, #b39ddb 0%, #9575cd 100%); /* deep-purple lighten-3 --> #9575cd deep-purple lighten-2 */
+}
+
 .collection {
     border-radius: 8px;
 }
@@ -207,4 +212,16 @@ form {
 }
 #formLoadingOverlay > .preloader-wrapper {
     top: 50%;
+}
+
+@media screen and (max-width:1000px) {
+    .btn.tokenButton {
+        display: none;
+    }
+}
+
+@media screen and (min-width:1000px) {
+    .btn.tokenButtonSideNav {
+        display: none;
+    }
 }


### PR DESCRIPTION
<!-- Which issue does this PR address? -->
Resolves #1417

<!-- What is the purpose of this PR? -->

This PR provides fixes to the UI of the topbar mainly, moving the "connect wallet" to the side nav in smaller devices, adding ellipsis if the name of the contributor is long.

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
Just minor html and css changes.

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
Please check on different screen sizes if this resolves the issue #1417

### Screenshots
<!-- If this PR affects the UI, please include screenshots demonstrating the changes. -->

Moved 'Connect wallet' to side nav in small screens:
![image](https://github.com/user-attachments/assets/4c62275d-4f84-48ae-9256-b52f8ee5089b)

displaying ellipsis when contributor name is long:
![image](https://github.com/user-attachments/assets/665e6107-e2ee-468a-9a04-2829e9ed53da)

Name further compacted in screens below 1000px in width:
![image](https://github.com/user-attachments/assets/b54ab7e3-e398-482d-af1c-0288aec00749)


<!-- Attribution: External code is properly credited. -->

---

### Format Checks
<!-- If this PR contains files with format violations, run 'mvn spotless:apply' to fix them. -->

> [!NOTE]
> Files in PRs are automatically checked for format violations with `mvn spotless:check`.

If this PR contains files with format violations, run `mvn spotless:apply` to fix them.
