### PR TITLE
Sort by ID during CSV export

### DIFF
--- a/src/main/java/ai/elimu/dao/EmojiDao.java
+++ b/src/main/java/ai/elimu/dao/EmojiDao.java
@@ -15,4 +15,6 @@ public interface EmojiDao extends GenericDao<Emoji> {
      * Fetch all Emojis that have been labeled by a Word.
      */
     List<Emoji> readAllLabeled(Word word) throws DataAccessException;
+    
+    List<Emoji> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/ImageDao.java
+++ b/src/main/java/ai/elimu/dao/ImageDao.java
@@ -17,4 +17,6 @@ public interface ImageDao extends GenericDao<Image> {
      * Fetch all Images that have been labeled by a Word.
      */
     List<Image> readAllLabeled(Word word) throws DataAccessException;
+    
+    List<Image> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/LetterDao.java
+++ b/src/main/java/ai/elimu/dao/LetterDao.java
@@ -12,4 +12,6 @@ public interface LetterDao extends GenericDao<Letter> {
     List<Letter> readAllOrdered() throws DataAccessException;
     
     List<Letter> readAllOrderedByUsage() throws DataAccessException;
+    
+    List<Letter> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/LetterSoundDao.java
+++ b/src/main/java/ai/elimu/dao/LetterSoundDao.java
@@ -14,4 +14,6 @@ public interface LetterSoundDao extends GenericDao<LetterSound> {
     List<LetterSound> readAllOrderedByUsage() throws DataAccessException;
     
     List<LetterSound> readAllOrderedByLettersLength() throws DataAccessException;
+    
+    List<LetterSound> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/NumberDao.java
+++ b/src/main/java/ai/elimu/dao/NumberDao.java
@@ -11,4 +11,6 @@ public interface NumberDao extends GenericDao<Number> {
     Number readByValue(Integer value) throws DataAccessException;
 
     List<Number> readAllOrdered() throws DataAccessException;
+    
+    List<Number> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/SoundDao.java
+++ b/src/main/java/ai/elimu/dao/SoundDao.java
@@ -16,4 +16,6 @@ public interface SoundDao extends GenericDao<Sound> {
     List<Sound> readAllOrderedByIpaValueCharacterLength() throws DataAccessException;
     
     List<Sound> readAllOrderedByUsage() throws DataAccessException;
+    
+    List<Sound> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/StoryBookDao.java
+++ b/src/main/java/ai/elimu/dao/StoryBookDao.java
@@ -16,4 +16,6 @@ public interface StoryBookDao extends GenericDao<StoryBook> {
     List<StoryBook> readAllOrdered(ReadingLevel readingLevel) throws DataAccessException;
     
     List<StoryBook> readAllUnleveled() throws DataAccessException;
+
+    List<StoryBook> readAllOrderedById() throws DataAccessException; // Pd3b6
 }

--- a/src/main/java/ai/elimu/dao/WordDao.java
+++ b/src/main/java/ai/elimu/dao/WordDao.java
@@ -20,4 +20,6 @@ public interface WordDao extends GenericDao<Word> {
     List<Word> readLatest() throws DataAccessException;
     
     List<Word> readInflections(Word word) throws DataAccessException;
+    
+    List<Word> readAllOrderedById() throws DataAccessException;
 }

--- a/src/main/java/ai/elimu/dao/jpa/EmojiDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/EmojiDaoJpa.java
@@ -44,4 +44,13 @@ public class EmojiDaoJpa extends GenericDaoJpa<Emoji> implements EmojiDao {
             .setParameter("word", word)
             .getResultList();
     }
+
+    @Override
+    public List<Emoji> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT e " +
+            "FROM Emoji e " +
+            "ORDER BY e.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/ImageDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/ImageDaoJpa.java
@@ -45,4 +45,13 @@ public class ImageDaoJpa extends GenericDaoJpa<Image> implements ImageDao {
             .setParameter("word", word)
             .getResultList();
     }
+
+    @Override
+    public List<Image> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT i " +
+            "FROM Image i " +
+            "ORDER BY i.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/LetterDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/LetterDaoJpa.java
@@ -41,4 +41,13 @@ public class LetterDaoJpa extends GenericDaoJpa<Letter> implements LetterDao {
             "ORDER BY l.usageCount DESC, l.text")
             .getResultList();
     }
+
+    @Override
+    public List<Letter> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT l " +
+            "FROM Letter l " +
+            "ORDER BY l.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/LetterSoundDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/LetterSoundDaoJpa.java
@@ -44,4 +44,13 @@ public class LetterSoundDaoJpa extends GenericDaoJpa<LetterSound> implements Let
             "ORDER BY lsc.letters.size DESC, lsc.usageCount DESC")
             .getResultList();
     }
+
+    @Override
+    public List<LetterSound> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT lsc " +
+            "FROM LetterSound lsc " +
+            "ORDER BY lsc.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/NumberDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/NumberDaoJpa.java
@@ -32,4 +32,13 @@ public class NumberDaoJpa extends GenericDaoJpa<Number> implements NumberDao {
             "ORDER BY n.value")
             .getResultList();
     }
+
+    @Override
+    public List<Number> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT n " +
+            "FROM Number n " +
+            "ORDER BY n.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/SoundDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/SoundDaoJpa.java
@@ -63,4 +63,13 @@ public class SoundDaoJpa extends GenericDaoJpa<Sound> implements SoundDao {
             "ORDER BY s.usageCount DESC, s.valueIpa")
             .getResultList();
     }
+
+    @Override
+    public List<Sound> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT s " +
+            "FROM Sound s " +
+            "ORDER BY s.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/StoryBookDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/StoryBookDaoJpa.java
@@ -54,4 +54,13 @@ public class StoryBookDaoJpa extends GenericDaoJpa<StoryBook> implements StoryBo
             "ORDER BY book.title")
             .getResultList();
     }
+
+    @Override
+    public List<StoryBook> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT book " +
+            "FROM StoryBook book " +
+            "ORDER BY book.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/dao/jpa/WordDaoJpa.java
+++ b/src/main/java/ai/elimu/dao/jpa/WordDaoJpa.java
@@ -88,4 +88,13 @@ public class WordDaoJpa extends GenericDaoJpa<Word> implements WordDao {
             .setParameter("word", word)
             .getResultList();
     }
+
+    @Override
+    public List<Word> readAllOrderedById() throws DataAccessException {
+        return em.createQuery(
+            "SELECT w " +
+            "FROM Word w " +
+            "ORDER BY w.id")
+            .getResultList();
+    }
 }

--- a/src/main/java/ai/elimu/web/content/emoji/EmojiCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/emoji/EmojiCsvExportController.java
@@ -36,7 +36,7 @@ public class EmojiCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<Emoji> emojis = emojiDao.readAllOrdered();
+        List<Emoji> emojis = emojiDao.readAllOrderedById();
         logger.info("emojis.size(): " + emojis.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/letter/LetterCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/letter/LetterCsvExportController.java
@@ -36,7 +36,7 @@ public class LetterCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<Letter> letters = letterDao.readAllOrderedByUsage();
+        List<Letter> letters = letterDao.readAllOrderedById();
         logger.info("letters.size(): " + letters.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/letter_sound/LetterSoundCsvExportController.java
@@ -37,7 +37,7 @@ public class LetterSoundCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<LetterSound> letterSounds = letterSoundDao.readAllOrderedByUsage();
+        List<LetterSound> letterSounds = letterSoundDao.readAllOrderedById();
         logger.info("letterSounds.size(): " + letterSounds.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/number/NumberCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/number/NumberCsvExportController.java
@@ -36,7 +36,7 @@ public class NumberCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<Number> numbers = numberDao.readAllOrdered();
+        List<Number> numbers = numberDao.readAllOrderedById();
         logger.info("numbers.size(): " + numbers.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/sound/SoundCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/sound/SoundCsvExportController.java
@@ -34,7 +34,7 @@ public class SoundCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<Sound> sounds = soundDao.readAllOrderedByUsage();
+        List<Sound> sounds = soundDao.readAllOrderedById();
         logger.info("sounds.size(): " + sounds.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/storybook/StoryBookCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/storybook/StoryBookCsvExportController.java
@@ -52,7 +52,7 @@ public class StoryBookCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<StoryBook> storyBooks = storyBookDao.readAllOrdered();
+        List<StoryBook> storyBooks = storyBookDao.readAllOrderedById();
         logger.info("storyBooks.size(): " + storyBooks.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT

--- a/src/main/java/ai/elimu/web/content/word/WordCsvExportController.java
+++ b/src/main/java/ai/elimu/web/content/word/WordCsvExportController.java
@@ -39,7 +39,7 @@ public class WordCsvExportController {
     ) throws IOException {
         logger.info("handleRequest");
         
-        List<Word> words = wordDao.readAllOrderedByUsage();
+        List<Word> words = wordDao.readAllOrderedById();
         logger.info("words.size(): " + words.size());
         
         CSVFormat csvFormat = CSVFormat.DEFAULT


### PR DESCRIPTION
Fixes #1999

Add methods to sort by ID in various DAO interfaces and implementations.

* **DAO Interfaces:**
  - Add `readAllOrderedById` method to `EmojiDao`, `ImageDao`, `LetterDao`, `LetterSoundDao`, `NumberDao`, `SoundDao`, `StoryBookDao`, and `WordDao` interfaces.

* **DAO Implementations:**
  - Implement `readAllOrderedById` method in `EmojiDaoJpa`, `ImageDaoJpa`, `LetterDaoJpa`, `LetterSoundDaoJpa`, `NumberDaoJpa`, `SoundDaoJpa`, `StoryBookDaoJpa`, and `WordDaoJpa` classes.

* **CSV Export Controllers:**
  - Update `EmojiCsvExportController` to use `emojiDao.readAllOrderedById`.
  - Update `LetterSoundCsvExportController` to use `letterSoundDao.readAllOrderedById`.
  - Update `LetterCsvExportController` to use `letterDao.readAllOrderedById`.
  - Update `NumberCsvExportController` to use `numberDao.readAllOrderedById`.
  - Update `SoundCsvExportController` to use `soundDao.readAllOrderedById`.
  - Update `StoryBookCsvExportController` to use `storyBookDao.readAllOrderedById`.
  - Update `WordCsvExportController` to use `wordDao.readAllOrderedById`.

