### PR TITLE
refactor: exclude outdated JUnit 3.8.2 dependency through jlayer (closes #2004)

### DIFF
--- a/pom-dependency-tree.txt
+++ b/pom-dependency-tree.txt
@@ -1,4 +1,4 @@
-ai.elimu:webapp:war:2.5.6-SNAPSHOT
+ai.elimu:webapp:war:2.5.7-SNAPSHOT
 +- com.github.elimu-ai:model:jar:model-2.0.77:compile
 |  \- com.google.code.gson:gson:jar:2.12.1:compile
 |     \- com.google.errorprone:error_prone_annotations:jar:2.36.0:compile
@@ -95,7 +95,6 @@ ai.elimu:webapp:war:2.5.6-SNAPSHOT
 |  \- org.java-websocket:Java-WebSocket:jar:1.3.8:compile
 +- org.aspectj:aspectjweaver:jar:1.9.22.1:compile
 +- com.googlecode.soundlibs:jlayer:jar:1.0.1.4:compile
-|  \- junit:junit:jar:3.8.2:compile
 +- com.googlecode.soundlibs:tritonus-share:jar:0.3.7.4:compile
 +- com.googlecode.soundlibs:mp3spi:jar:1.9.5.4:compile
 +- org.bitbucket.ijabz:jaudiotagger:jar:3.0.1:compile

--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,12 @@
             <groupId>com.googlecode.soundlibs</groupId>
             <artifactId>jlayer</artifactId>
             <version>1.0.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.googlecode.soundlibs</groupId>


### PR DESCRIPTION
…ses #2004)

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #2004 

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* Remove outdated JUnit 3.8.2 dependency that comes transitively through jlayer

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* exclusion from pom.xml

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* Check `pom-dependency-tree.txt`

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
* Not Applicable

<!-- Attribution: External code is properly credited. -->
Not Applicable
---

### Format Checks
<!-- If this PR contains files with format violations, run 'mvn spotless:apply' to fix them. -->

> [!NOTE]
> Files in PRs are automatically checked for format violations with `mvn spotless:check`.

If this PR contains files with format violations, run `mvn spotless:apply` to fix them.

Reviewers: @jo-elimu @nya-elimu @gscdev 
