### PR TITLE
Fix Thai diacritic input validation

### DIFF
--- a/src/main/java/ai/elimu/model/content/Letter.java
+++ b/src/main/java/ai/elimu/model/content/Letter.java
@@ -9,8 +9,8 @@ import jakarta.validation.constraints.Size;
 public class Letter extends Content {
 
     @NotNull
-    @Size(max = 2)
-    @Column(length = 2)
+    @Size(max = 3)
+    @Column(length = 3)
     private String text;
 
     private boolean diacritic;


### PR DESCRIPTION
Fixes #1996

Increase the `@Size` and `@Column` annotation limits for the `text` field in `Letter.java` to 3 characters.

* Update `@Size` annotation for the `text` field to 3 characters.
* Update `@Column` annotation for the `text` field to 3 characters.

