### PR TITLE
fix: letter text is too long (thai)

### DIFF
--- a/pom-dependency-tree.txt
+++ b/pom-dependency-tree.txt
@@ -1,4 +1,4 @@
-ai.elimu:webapp:war:2.6.5-SNAPSHOT
+ai.elimu:webapp:war:2.6.7-SNAPSHOT
 +- ai.elimu:model:jar:model-2.0.97:compile
 |  \- com.google.code.gson:gson:jar:2.13.0:compile
 |     \- com.google.errorprone:error_prone_annotations:jar:2.37.0:compile

--- a/src/main/java/ai/elimu/entity/content/Letter.java
+++ b/src/main/java/ai/elimu/entity/content/Letter.java
@@ -13,8 +13,8 @@ import lombok.Setter;
 public class Letter extends Content {
 
   @NotNull
-  @Size(max = 2)
-  @Column(length = 2)
+  @Size(max = 3)
+  @Column(length = 3)
   private String text;
 
   private boolean diacritic;

--- a/src/main/resources/META-INF/jpa-schema-export.sql
+++ b/src/main/resources/META-INF/jpa-schema-export.sql
@@ -264,7 +264,7 @@
         timeLastUpdate datetime,
         usageCount integer,
         diacritic bit not null,
-        text varchar(2),
+        text varchar(3),
         primary key (id)
     ) type=MyISAM;
 

--- a/src/main/resources/db/migration/2006007.sql
+++ b/src/main/resources/db/migration/2006007.sql
@@ -1,0 +1,3 @@
+# 2.6.7
+
+ALTER TABLE `Letter` MODIFY `text` VARCHAR(3) NOT NULL;

--- a/src/main/webapp/WEB-INF/jsp/content/letter/create.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/letter/create.jsp
@@ -11,7 +11,7 @@
             <div class="row">
                 <div class="input-field col s12">
                     <form:label path="text" cssErrorClass="error">Text</form:label>
-                    <form:input path="text" cssErrorClass="error" />
+                    <form:input path="text" cssErrorClass="error" maxlength="3" />
                 </div>
             </div>
                 

--- a/src/main/webapp/WEB-INF/jsp/content/letter/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/letter/edit.jsp
@@ -31,7 +31,7 @@
             <div class="row">
                 <div class="input-field col s12">
                     <form:label path="text" cssErrorClass="error">Text</form:label>
-                    <form:input path="text" cssErrorClass="error" />
+                    <form:input path="text" cssErrorClass="error" maxlength="3" />
                 </div>
             </div>
 


### PR DESCRIPTION
closes #2011

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #1996

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
* 

<!-- Attribution: External code is properly credited. -->

---

### Format Checks
<!-- If this PR contains files with format violations, run 'mvn spotless:apply' to fix them. -->

> [!NOTE]
> Files in PRs are automatically checked for format violations with `mvn spotless:check`.

If this PR contains files with format violations, run `mvn spotless:apply` to fix them.
