### PR TITLE
refactor:Add min/max validation constraint to attribute

### DIFF
--- a/src/main/java/ai/elimu/entity/analytics/LetterSoundAssessmentEvent.java
+++ b/src/main/java/ai/elimu/entity/analytics/LetterSoundAssessmentEvent.java
@@ -1,6 +1,8 @@
 package ai.elimu.entity.analytics;
 
 import jakarta.persistence.Entity;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -29,6 +31,8 @@ public class LetterSoundAssessmentEvent extends AssessmentEvent {
     /**
      * A value in the range [0.0, 1.0].
      */
+    @Min(value = 0, message = "Mastery score must be at least 0")
+    @Max(value = 1, message = "Mastery score must not exceed 1")
     private Float masteryScore;
 
     /**


### PR DESCRIPTION
### Issue Number
* Resolves #2198 

### Purpose
* The attribute masteryScore need a validation for only having values between 0.0 and 1.0

### Technical Details
Used Jakarta Bean Validation Annotation.

<img width="623" alt="Screenshot 2025-05-29 at 2 55 25 p m" src="https://github.com/user-attachments/assets/4bf58041-89df-4f4f-a61a-3d786d8bb356" />
