### PR TITLE
refactor(data): handle removal of the learning event type

### DIFF
--- a/src/main/java/ai/elimu/util/csv/CsvAnalyticsExtractionHelper.java
+++ b/src/main/java/ai/elimu/util/csv/CsvAnalyticsExtractionHelper.java
@@ -312,9 +312,11 @@ public class CsvAnalyticsExtractionHelper {
                     numberLearningEvent.setAdditionalData(additionalData);
                 }
 
-                if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
-                    LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
-                    numberLearningEvent.setLearningEventType(learningEventType);
+                if (versionCode < 4000033) {
+                    if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
+                        LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
+                        numberLearningEvent.setLearningEventType(learningEventType);
+                    }
                 }
 
                 if (versionCode >= 3005009) {
@@ -481,9 +483,11 @@ public class CsvAnalyticsExtractionHelper {
                 String packageName = csvRecord.get("package_name");
                 wordLearningEvent.setPackageName(packageName);
 
-                if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
-                    LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
-                    wordLearningEvent.setLearningEventType(learningEventType);
+                if (versionCode < 4000033) {
+                    if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
+                        LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
+                        wordLearningEvent.setLearningEventType(learningEventType);
+                    }
                 }
 
                 if (versionCode >= 3006000) {
@@ -568,9 +572,11 @@ public class CsvAnalyticsExtractionHelper {
                 String packageName = csvRecord.get("package_name");
                 storyBookLearningEvent.setPackageName(packageName);
 
-                if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
-                    LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
-                    storyBookLearningEvent.setLearningEventType(learningEventType);
+                if (versionCode < 4000033) {
+                    if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
+                        LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
+                        storyBookLearningEvent.setLearningEventType(learningEventType);
+                    }
                 }
 
                 if (versionCode >= 3006000) {
@@ -653,9 +659,11 @@ public class CsvAnalyticsExtractionHelper {
                 String packageName = csvRecord.get("package_name");
                 videoLearningEvent.setPackageName(packageName);
 
-                if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
-                    LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
-                    videoLearningEvent.setLearningEventType(learningEventType);
+                if (versionCode < 4000033) {
+                    if (StringUtils.isNotBlank(csvRecord.get("learning_event_type"))) {
+                        LearningEventType learningEventType = LearningEventType.valueOf(csvRecord.get("learning_event_type"));
+                        videoLearningEvent.setLearningEventType(learningEventType);
+                    }
                 }
 
                 String additionalData = csvRecord.get("additional_data");


### PR DESCRIPTION
Resolves data batch processing error:
```
Error during import of video learning events: class java.lang.IllegalArgumentException: Mapping for learning_event_type not found, expected one of [id, timestamp, package_name, additional_data, research_experiment, experiment_group, video_title, video_id]
```

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
* 

<!-- Attribution: External code is properly credited. -->

---

### Format Checks
<!-- If this PR contains files with format violations, run 'mvn spotless:apply' to fix them. -->

> [!NOTE]
> Files in PRs are automatically checked for format violations with `mvn spotless:check`.

If this PR contains files with format violations, run `mvn spotless:apply` to fix them.
