### PR TITLE
closes #2327 - Word labels incorrectly removed when editing emoji

### DIFF
--- a/src/main/java/ai/elimu/web/content/emoji/EmojiEditController.java
+++ b/src/main/java/ai/elimu/web/content/emoji/EmojiEditController.java
@@ -92,19 +92,24 @@ public class EmojiEditController {
 
       return "content/emoji/edit";
     } else {
-      emoji.setRevisionNumber(emoji.getRevisionNumber() + 1);
-      emojiDao.update(emoji);
+      Emoji persistentEmoji = emojiDao.read(emoji.getId());
+      persistentEmoji.setGlyph(emoji.getGlyph());
+      persistentEmoji.setUnicodeVersion(emoji.getUnicodeVersion());
+      persistentEmoji.setUnicodeEmojiVersion(emoji.getUnicodeEmojiVersion());
+      persistentEmoji.setRevisionNumber(persistentEmoji.getRevisionNumber() + 1);
+
+      emojiDao.update(persistentEmoji);
 
       EmojiContributionEvent emojiContributionEvent = new EmojiContributionEvent();
       emojiContributionEvent.setContributor((Contributor) session.getAttribute("contributor"));
       emojiContributionEvent.setTimestamp(Calendar.getInstance());
-      emojiContributionEvent.setEmoji(emoji);
-      emojiContributionEvent.setRevisionNumber(emoji.getRevisionNumber());
+      emojiContributionEvent.setEmoji(persistentEmoji);
+      emojiContributionEvent.setRevisionNumber(persistentEmoji.getRevisionNumber());
       emojiContributionEventDao.create(emojiContributionEvent);
 
-      DiscordHelper.postToChannel(Channel.CONTENT, "Emoji " + emoji.getGlyph() + " updated: " + DomainHelper.getBaseUrl() + "/content/emoji/edit/" + emoji.getId());
+      DiscordHelper.postToChannel(Channel.CONTENT, "Emoji " + persistentEmoji.getGlyph() + " updated: " + DomainHelper.getBaseUrl() + "/content/emoji/edit/" + persistentEmoji.getId());
 
-      return "redirect:/content/emoji/list#" + emoji.getId();
+      return "redirect:/content/emoji/list#" + persistentEmoji.getId();
     }
   }
 


### PR DESCRIPTION
**### Issue Number**
* Resolves [#2327](https://github.com/elimu-ai/webapp/issues/2327)

**### Purpose**
* When an emoji is edited, existing word labels are removed.

### Technical Details
* Issue: The `Emoji` object passed to `handleSubmit` contained `null` in the `words` field. When calling `emojiDao.update(emoji)`, this overwrote the existing `words` in the database with `null`, causing them to be removed.
* Fix: Instead of updating directly with the detached `emoji` object, the persistent `existingEmoji` is loaded from the database. Its scalar fields (`glyph`, `unicodeVersion`, `unicodeEmojiVersion`, `revisionNumber`) are updated, and then `emojiDao.update(existingEmoji)` is called. This preserves the associated `words`.

### Testing Instructions
* Open any existing emoji or create a new one
* Add any words to it
* Update any value (Glyph, Unicode version or Enicode Emoji version) and click Edit

### Screenshots
* Before: 
<img width="1253" height="535" alt="image" src="https://github.com/user-attachments/assets/d52ccf9e-c9be-41f8-96ce-4e71fc6e85b2" />
* After updating Unicode Emoji version to 2: 
<img width="1253" height="229" alt="image" src="https://github.com/user-attachments/assets/cdd2fa0d-8677-41d2-a423-d06fe1ec4e9a" />
