### PR TITLE
Closes #1982. Integrate Log4j with Jakarta EE

### DIFF
--- a/pom-dependency-tree.txt
+++ b/pom-dependency-tree.txt
@@ -1,4 +1,4 @@
-ai.elimu:webapp:war:2.6.157-SNAPSHOT
+ai.elimu:webapp:war:2.6.158-SNAPSHOT
 +- ai.elimu:model:jar:model-2.0.139:compile
 |  \- com.google.code.gson:gson:jar:2.13.2:compile
 |     \- com.google.errorprone:error_prone_annotations:jar:2.41.0:compile
@@ -19,6 +19,7 @@ ai.elimu:webapp:war:2.6.157-SNAPSHOT
 +- org.apache.logging.log4j:log4j-core:jar:2.25.3:compile
 +- org.apache.logging.log4j:log4j-slf4j2-impl:jar:2.24.3:runtime
 |  \- org.slf4j:slf4j-api:jar:2.0.16:compile
++- org.apache.logging.log4j:log4j-jakarta-web:jar:2.25.3:runtime
 +- commons-lang:commons-lang:jar:2.6:compile
 +- org.apache.commons:commons-csv:jar:1.14.0:compile
 |  +- commons-io:commons-io:jar:2.18.0:compile

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <jetty.version>11.0.24</jetty.version>
     <spring.version>6.0.11</spring.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <log4j.version>2.25.3</log4j.version>
     <lombok.version>1.18.38</lombok.version>
   </properties>
 
@@ -357,13 +358,19 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.25.3</version>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
       <version>2.24.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jakarta-web</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Apache Commons -->

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,6 +5,14 @@
         <param-value>/WEB-INF/spring/applicationContext*.xml</param-value>
     </context-param>
     <listener>
+        <description>Handles Log4j Core lifecycle</description>
+        <listener-class>org.apache.logging.log4j.web.Log4jServletContextListener</listener-class>
+        <!-- Log4jServletContextListener should be the first context listener to correctly handle
+             with ${web:attr.content_language} (see the issue #1982). See also
+             https://logging.apache.org/log4j/2.x/jakarta.html
+          -->
+    </listener>
+    <listener>
         <listener-class>ai.elimu.web.context.EnvironmentContextLoaderListener</listener-class>
     </listener>
     <servlet>


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #1982

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* Restore proper detection of the `content_language` attribute during logging after the transition to Jakarta

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* Added log4j-jakarta-web dependency and Log4jServletContextListener (in the first position) in web.xml according to ["Integrating with Jakarta EE"](https://logging.apache.org/log4j/2.x/jakarta.html)
* Should I align the version of all Log4j modules (log4j-api, log4j-core, log4j-slf4j2-impl, log4j-jakarta-web)? If so, which version should I select: 2.24.3 (currently used by log4j-api and log4j-slf4j2-impl), 2.25.3 (used by log4j-core and log4j-jakarta-web) or 2.25.4 (the latest)?

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* Verify that logs are created in language-specific folders and that the `[content_language]` prefix appears in the log entries

<!-- Attribution: External code is properly credited. -->
Added external library log4j-jakarta-web 2.25.3 has Apache-2.0 license.

---

### Format Checks
<!-- If this PR contains files with format violations, run 'mvn spotless:apply' to fix them. -->

> [!NOTE]
> Files in PRs are automatically checked for format violations with `mvn spotless:check`.

If this PR contains files with format violations, run `mvn spotless:apply` to fix them.
