### PR TITLE
Closes #1982. Replace initialize with reconfigure for log configuration on CentOS

### DIFF
--- a/src/main/java/ai/elimu/web/context/EnvironmentContextLoaderListener.java
+++ b/src/main/java/ai/elimu/web/context/EnvironmentContextLoaderListener.java
@@ -20,6 +20,7 @@ import ai.elimu.model.v2.enums.Environment;
 import ai.elimu.model.v2.enums.Language;
 import ai.elimu.util.ConfigHelper;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -34,6 +35,8 @@ public class EnvironmentContextLoaderListener extends ContextLoaderListener {
     public static Environment env = Environment.DEV;
     
     public final static Properties PROPERTIES = new Properties();
+
+    private static final String FAILED_MESSAGE_TEMPLATE = "Failed to reconfigure logging to %s. ";
 
     private Logger logger = LogManager.getLogger();
 
@@ -57,19 +60,35 @@ public class EnvironmentContextLoaderListener extends ContextLoaderListener {
         PROPERTIES.put("env", env);
         
         if (env == Environment.PROD) {
-            // Configure Log4j 2 so that it logs to a file instead of to the console
-            // See https://logging.apache.org/log4j/2.x/manual/customconfig.html#Configurator)
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            URL log4j2FileUrl = classLoader.getResource("log4j2_" + env + ".xml");
-            logger.info("log4j2FileUrl: " + log4j2FileUrl);
-            String log4j2FilePath = log4j2FileUrl.getFile();
-            logger.info("log4j2FilePath: " + log4j2FilePath);
-            Configurator.initialize(null, log4j2FilePath);
-            logger = LogManager.getLogger();
-            logger.info("log4j2FilePath: " + log4j2FilePath);
+            reconfigureLog4j();
         }
 
         super.contextInitialized(event);
+    }
+
+    /**
+     * Reconfigure Log4j 2 so that it logs to a file instead of to the console.
+     * 
+     * @see https://logging.apache.org/log4j/2.x/manual/customconfig.html#Configurator
+     */
+    private void reconfigureLog4j() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        String log4j2FileName = "log4j2_" + env + ".xml";
+        URL log4j2FileUrl = classLoader.getResource(log4j2FileName);
+        if (log4j2FileUrl == null) {
+            logger.error(FAILED_MESSAGE_TEMPLATE.formatted(log4j2FileName)
+                    + "File could not be found.");
+            return;
+        }
+        logger.info("log4j2FileUrl: " + log4j2FileUrl);
+        try {
+            Configurator.reconfigure(log4j2FileUrl.toURI());
+            logger = LogManager.getLogger();
+            logger.info("log4j2FileUrl: " + log4j2FileUrl);
+        } catch (URISyntaxException e) {
+            logger.error(FAILED_MESSAGE_TEMPLATE.formatted(log4j2FileName)
+                    + "URL cannot be converted to a URI.", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #1982

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* To fix [the issue with applying prod-config on the production server](https://github.com/elimu-ai/webapp/pull/2377#issuecomment-4385866923)

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* After [adding log4j-jakarta-web dependency and Log4jServletContextListener to web.xml](https://github.com/elimu-ai/webapp/commit/7a321c965e97097af666181168e4bf5744d9f90e) the [initialize](https://github.com/elimu-ai/webapp/blob/webapp-2.6.158/src/main/java/ai/elimu/web/context/EnvironmentContextLoaderListener.java#L67) method failed to switch the logging configuration to `log4j2_PROD.xml` on CentOS (though it worked on Windows)
* Relevant log entry
> 2026-05-06T07:02:24.746143047Z main WARN locateContext called with URI /tmp/jetty-0_0_0_0-80-webapp_war-_-vie_elimu_ai-1869597092899476373/webapp/WEB-INF/classes/log4j2_PROD.xml. Existing LoggerContext has URI file:/tmp/jetty-0_0_0_0-80-webapp_war-_-vie_elimu_ai-1869597092899476373/webapp/WEB-INF/classes/log4j2.xml
* Replaced the `initialize` method with `reconfigure` method

### How did I test?
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* Set up a CentOS Stream 9 virtual machine with Java, Jetty and MariaDB;
* Deployed the webapp and verify that log files are now correctly generated in the `lang-ENG/logs` folder.

<!-- Attribution: External code is properly credited. -->